### PR TITLE
fix: use implicitWidth/implicitHeight on PanelWindow (deprecation fix)

### DIFF
--- a/Carousel.qml
+++ b/Carousel.qml
@@ -765,7 +765,7 @@ Item {
         id: cacheWindow
         visible: true
         color: "transparent"
-        width: 1; height: 1
+        implicitWidth: 1; implicitHeight: 1
 
         WlrLayershell.namespace: root.wlrNamespace + ":precache"
         WlrLayershell.layer: WlrLayershell.Background


### PR DESCRIPTION
PanelWindow with WlrLayershell ancestor warns:
- Setting `width` is deprecated. Set `implicitWidth` instead
- Setting `height` is deprecated. Set `implicitHeight` instead

Changed the pre-cache window in `Carousel.qml` to use `implicitWidth`/`implicitHeight`. The child `Item` inside is left unchanged — it is not a PanelWindow and does not trigger the warning.